### PR TITLE
Add color modality

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,6 @@
 - [x] Manage body background with [React Helmet](https://github.com/nfl/react-helmet)
 - [x] Split into smart and dumb components
 - [x] Switch to [Reach Router](https://github.com/reach/router)
-- [ ] Add other color modes
+- [x] Add other color modes
+- [ ] Adjust text color to contrast with background
+- [ ] Simplify styling with [Styled Components](https://github.com/styled-components/styled-components)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "color-clock",
-  "version": "0.1.12",
+  "value": "color-clock",
+  "version": "0.2.0",
   "main": "src/index.jsx",
   "author": "Martin Rosenberg",
   "private": true,

--- a/src/components/Clock/constants.js
+++ b/src/components/Clock/constants.js
@@ -1,9 +1,4 @@
 export const style = {
-  alignItems: 'center',
   color: '#eeeeee',
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  height: '100vh',
-  width: '100vw',
+  textAlign: 'center',
 }

--- a/src/components/Clock/index.jsx
+++ b/src/components/Clock/index.jsx
@@ -5,7 +5,7 @@ import { style } from './constants'
 
 export const Clock = ({ color, time }) => (
   <div style={style}>
-    <h1>{time}</h1>
+    <h1 style={{ margin: 0 }}>{time}</h1>
     <h2>{color}</h2>
   </div>
 )

--- a/src/components/Clock/tests/__snapshots__/index.test.jsx.snap
+++ b/src/components/Clock/tests/__snapshots__/index.test.jsx.snap
@@ -4,17 +4,18 @@ exports[`Clock component should render correctly 1`] = `
 <div
   style={
     Object {
-      "alignItems": "center",
       "color": "#eeeeee",
-      "display": "flex",
-      "flexDirection": "column",
-      "height": "100vh",
-      "justifyContent": "center",
-      "width": "100vw",
+      "textAlign": "center",
     }
   }
 >
-  <h1>
+  <h1
+    style={
+      Object {
+        "margin": 0,
+      }
+    }
+  >
     12:34:56
   </h1>
   <h2>

--- a/src/components/Content/constants.js
+++ b/src/components/Content/constants.js
@@ -1,0 +1,8 @@
+export const style = {
+  alignItems: 'center',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  height: '100vh',
+  width: '100vw',
+}

--- a/src/components/Content/index.jsx
+++ b/src/components/Content/index.jsx
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import { style } from './constants'
+
+export const Content = ({ children }) =>
+  <div style={style}>
+    {children}
+  </div>
+
+Content.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ])
+}

--- a/src/components/Content/tests/__snapshots__/index.test.jsx.snap
+++ b/src/components/Content/tests/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Content component should render correctly 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "height": "100vh",
+      "justifyContent": "center",
+      "width": "100vw",
+    }
+  }
+/>
+`;

--- a/src/components/Content/tests/index.test.jsx
+++ b/src/components/Content/tests/index.test.jsx
@@ -1,0 +1,10 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import { Content } from '../index'
+
+describe('Content component', () => {
+  test('should render correctly', () => {
+    const wrapper = shallow(<Content/>)
+    expect(wrapper).toMatchSnapshot()
+  })
+})

--- a/src/components/ModeButtons/constants.js
+++ b/src/components/ModeButtons/constants.js
@@ -1,0 +1,8 @@
+export const style = {
+  background: '#fff9',
+  border: 0,
+  cursor: 'pointer',
+  borderRadius: '0.25rem',
+  margin: '0.5rem',
+  padding: '1rem',
+}

--- a/src/components/ModeButtons/index.jsx
+++ b/src/components/ModeButtons/index.jsx
@@ -1,0 +1,22 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import { Modes } from '../../containers/App/constants'
+import { style } from './constants'
+
+export const ModeButtons = ({ handleSetMode }) =>
+  <div>
+    {Object.values(Modes).map((mode) =>
+      <button
+        key={mode.value}
+        onClick={() => handleSetMode(mode.value)}
+        style={style}
+      >
+        {mode.name}
+      </button>
+    )}
+  </div>
+
+ModeButtons.propTypes = {
+  handleSetMode: PropTypes.func.isRequired
+}

--- a/src/components/ModeButtons/tests/__snapshots__/index.test.jsx.snap
+++ b/src/components/ModeButtons/tests/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModeButtons component should render correctly 1`] = `
+<div>
+  <button
+    key="simple"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#fff9",
+        "border": 0,
+        "borderRadius": "0.25rem",
+        "margin": "0.5rem",
+        "padding": "1rem",
+      }
+    }
+  >
+    Simple
+  </button>
+  <button
+    key="rent"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#fff9",
+        "border": 0,
+        "borderRadius": "0.25rem",
+        "margin": "0.5rem",
+        "padding": "1rem",
+      }
+    }
+  >
+    RENT
+  </button>
+  <button
+    key="sunrise"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#fff9",
+        "border": 0,
+        "borderRadius": "0.25rem",
+        "margin": "0.5rem",
+        "padding": "1rem",
+      }
+    }
+  >
+    Sunrise
+  </button>
+  <button
+    key="unix"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#fff9",
+        "border": 0,
+        "borderRadius": "0.25rem",
+        "margin": "0.5rem",
+        "padding": "1rem",
+      }
+    }
+  >
+    Unix
+  </button>
+</div>
+`;

--- a/src/components/ModeButtons/tests/index.test.jsx
+++ b/src/components/ModeButtons/tests/index.test.jsx
@@ -1,0 +1,22 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import { ModeButtons } from '../index'
+
+let handleSetMode
+
+beforeEach(() => {
+  handleSetMode = jest.fn()
+})
+
+describe('ModeButtons component', () => {
+  test('should render correctly', () => {
+    const wrapper = shallow(<ModeButtons handleSetMode={handleSetMode}/>)
+    expect(wrapper).toMatchSnapshot()
+  })
+})
+
+
+describe(`button`, () => {
+  test('should call handleSetMode with correct mode', () => {})
+})

--- a/src/containers/App/constants.js
+++ b/src/containers/App/constants.js
@@ -1,0 +1,35 @@
+const getHex = (length) => (decimal) =>
+  Math.round(decimal).toString(16).padStart(length, '0')
+
+export const Modes = Object.freeze({
+  simple: {
+    name: 'Simple',
+    value: 'simple',
+    getColor: (time) => time.format('#HHmmss'),
+  },
+  rent: {
+    name: 'RENT',
+    value: 'rent',
+    getColor: (time) => {
+      const secOfDay = time.diff(time.clone().startOf('day'), 'seconds')
+      return `#${getHex(6)(secOfDay * 194.18298)}`
+    }
+  },
+  sunrise: {
+    name: 'Sunrise',
+    value: 'sunrise',
+    getColor: (time) => {
+      const red = getHex(2)(time.hour() * 11.09)
+      const green = getHex(2)(time.minute() * 4.32)
+      const blue = getHex(2)(time.second() * 4.32)
+      return `#${red}${green}${blue}`
+    },
+  },
+  unix: {
+    name: 'Unix',
+    value: 'unix',
+    getColor: (time) => `#${getHex(6)(time.valueOf() % 16777215)}`
+  },
+})
+
+export const defaultMode = Modes.simple.value

--- a/src/containers/App/index.jsx
+++ b/src/containers/App/index.jsx
@@ -1,21 +1,26 @@
 import React, { Component, Fragment } from 'react'
 
-import { getColorAndFormattedTime } from './utils'
 import { Body } from '../../components/Body'
 import { Clock } from '../../components/Clock'
+import { ModeButtons } from '../../components/ModeButtons'
+import { defaultMode } from './constants'
+import { getColorAndTime } from './utils'
+import { Content } from '../../components/Content'
 
 export class App extends Component {
   state = {
-    ...getColorAndFormattedTime(),
-    ticker: null
+    ...getColorAndTime(defaultMode),
+    mode: defaultMode,
+    ticker: null,
   }
 
-  tick = () => {
-    this.setState(() => getColorAndFormattedTime())
+  handleSetMode = (mode) => {
+    this.setState(() => ({ ...getColorAndTime(mode), mode }))
   }
 
   componentDidMount () {
-    this.setState(() => ({ ticker: setInterval(this.tick, 1000) }))
+    const tick = () => this.setState(() => getColorAndTime(this.state.mode))
+    this.setState(() => ({ ticker: setInterval(tick, 1000) }))
   }
 
   componentWillUnmount () {
@@ -27,7 +32,10 @@ export class App extends Component {
     return (
       <Fragment>
         <Body color={color}/>
-        <Clock color={color} time={time}/>
+        <Content>
+          <Clock color={color} time={time}/>
+          <ModeButtons handleSetMode={this.handleSetMode}/>
+        </Content>
       </Fragment>
     )
   }

--- a/src/containers/App/tests/__snapshots__/index.test.jsx.snap
+++ b/src/containers/App/tests/__snapshots__/index.test.jsx.snap
@@ -5,9 +5,14 @@ exports[`App container should render correctly 1`] = `
   <Body
     color="#180000"
   />
-  <Clock
-    color="#180000"
-    time="18:00:00"
-  />
+  <Content>
+    <Clock
+      color="#180000"
+      time="18:00:00"
+    />
+    <ModeButtons
+      handleSetMode={[Function]}
+    />
+  </Content>
 </Fragment>
 `;

--- a/src/containers/App/tests/index.test.jsx
+++ b/src/containers/App/tests/index.test.jsx
@@ -3,12 +3,11 @@ import React from 'react'
 
 import { App } from '..'
 
-describe('App container', () => {
-  beforeEach(() => {
-    // Moment uses `Date` internally, so overwriting `Date.now` is a simple mock
-    Date.now = jest.fn(() => 0)
-  })
+beforeEach(() => {
+  Date.now = jest.fn(() => 0)
+})
 
+describe('App container', () => {
   test('should render correctly', () => {
     const wrapper = shallow(<App/>)
     expect(wrapper).toMatchSnapshot()

--- a/src/containers/App/tests/utils.test.js
+++ b/src/containers/App/tests/utils.test.js
@@ -1,14 +1,28 @@
-import { getColorAndFormattedTime } from '../utils'
+import { Modes } from '../constants'
+import { getColorAndTime } from '../utils'
 
 beforeEach(() => {
   Date.now = jest.fn(() => 0)
 })
 
-describe('getColorAndFormattedTime', () => {
-  test('should correctly derive color and formatted time', () => {
-    expect(getColorAndFormattedTime()).toEqual({
-      color: '#180000',
-      time: '18:00:00',
+describe('getColorAndTime', () => {
+  test('should return color and formatted time', () => {
+    const res = getColorAndTime(Modes.simple.value)
+    expect(res).toMatchObject({
+      time: expect.stringMatching(/^\d{1,2}:\d{2}:\d{2}$/),
+      color: expect.stringMatching(/^#\d{6}$/),
+    })
+  })
+
+  const testCases = [
+    { mode: Modes.simple, color: '#180000' },
+    { mode: Modes.rent, color: '#bfffff' },
+    { mode: Modes.sunrise, color: '#c80000' },
+    { mode: Modes.unix, color: '#000000' },
+  ]
+  testCases.map(({ mode, color }) => {
+    test(`should correctly derive color in ${mode.name} mode`, () => {
+      expect(getColorAndTime(mode.value)).toMatchObject({ color })
     })
   })
 })

--- a/src/containers/App/utils.js
+++ b/src/containers/App/utils.js
@@ -1,9 +1,8 @@
 import moment from 'moment'
 
-export const getColorAndFormattedTime = () => {
-  const time = moment()
-  return {
-    color: time.format('#HHmmss'),
-    time: time.format('H:mm:ss'),
-  }
-}
+import { Modes } from './constants'
+
+export const getColorAndTime = (mode, time = moment()) => ({
+  color: Modes[mode].getColor(time),
+  time: time.format('H:mm:ss'),
+})


### PR DESCRIPTION
Previously, the background color was only derived by using the current `HH:mm:ss` time as a hex value, resulting in always-dark colors. This change introduces several modes of color derivation, as well as a set of buttons to switch between them.